### PR TITLE
Fixing default require path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 module.exports = function (pkgDir) {
-  var dir = pkgDir || '.'
-  var pkg = require(dir + "/package.json");
+  var dir = pkgDir || '../..';
+  var pkg;
+  if (typeof pkgDir === 'object'){
+    pkg = pkgDir;
+  } else {
+    pkg = require(dir + "/package.json");
+  }
+
   var requiredVersion = pkg.engines.node.replace(">=", "");
   var currentVersion = process.version.replace("v", "");
   if (currentVersion < requiredVersion) {
     console.error(
-      "%s requires at least version %s of Node, please upgrade",
+      "\n%s requires at least version %s of Node, please upgrade\n",
       pkg.name,
       requiredVersion
     );


### PR DESCRIPTION
In reference to issue #1, this will allow the module to be used like this by default:

````js
require('please-upgrade-node')()
````

No need to parse any arguments into it.

What you had before (`var pkg = require("./package.json");`) was just looking at the package.json file of "please-upgrade-node", not the users package.json file. This commit ensures that it is looking at the users package.json file by default.

It still allows the use of both strings and objects if for whatever reason the project doesn't have the expected folder structure. This will work in the vast majority of instances though like 99.999% sort of thing.

I also added "\n" to the start and end of the error message. This makes the error message stand out a lot more as it separates the error message from any other text that is in the console. This makes it easier to see, and easier to read read when it pops.