### PR TITLE
Use caller's dir for pkg resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Please upgrade Node [![Build Status](https://travis-ci.org/typicode/please-upgrade-node.svg?branch=master)](https://travis-ci.org/typicode/please-upgrade-node) [![npm](https://img.shields.io/npm/v/please-upgrade-node.svg)](https://www.npmjs.com/package/please-upgrade-node)
 
-> :information_desk_person: show a message to your users to upgrade Node instead of a stacktrace 
+> :information_desk_person: show a message to your users to upgrade Node instead of a stacktrace
 
 It's common for new Node users to miss the `npm` engines warning when installing a CLI. This package displays a beginner-friendly message if their Node version is below the one expected.
 
@@ -27,12 +27,14 @@ require('please-upgrade-node')()
 
 ```js
 // package.json
-{ 
+{
   "name": "super-cli",
   "bin": "./bin.js",
   "engines": { "node": ">=6" }
 }
 ```
+
+Note that `package.json` will be resolved relative to _your file_.
 
 ## Caveats
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
-module.exports = function (pkgDir) {
-  var dir = pkgDir || '.'
+var path = require("path");
+
+module.exports = function pleaseUpgradeNode(pkgDir) {
+  // This will give us the directory where please-upgrade-node was required from
+  var requiredFrom = path.dirname(module.parent.filename);
+  // If the user passes `pkgDir` as `'..'`, that should be resolved
+  // relative to his __dirname
+  var dir = pkgDir ? path.resolve(requiredFrom, pkgDir) : requiredFrom;
   var pkg = require(dir + "/package.json");
   var requiredVersion = pkg.engines.node.replace(">=", "");
   var currentVersion = process.version.replace("v", "");

--- a/package.json
+++ b/package.json
@@ -22,6 +22,13 @@
     "upgrade"
   ],
   "author": "typicode",
+  "contributors": [
+    {
+      "name": "Suhas Karanth",
+      "email": "sudo.suhas@gmail.com",
+      "url": "github.com/sudo-suhas"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/typicode/please-upgrade-node/issues"

--- a/test.js
+++ b/test.js
@@ -1,13 +1,15 @@
 var assert = require("assert");
-var mock = require('mock-require')
+var path = require("path");
+var mock = require("mock-require");
 var pleaseUpgrade = require("./");
 
 Object.defineProperty(process, "version", { value: "v4.0.0" });
 
 var count = 0;
-var name = 'Lorem Ipsum'
+var name = "Lorem Ipsum";
+var defaultPkgPath = __dirname + "/package.json";
 
-process.exit = function (code) {
+process.exit = function(code) {
   count = count + 1;
 };
 
@@ -16,16 +18,16 @@ function countShouldBe(expected) {
 }
 
 // Should not call process.exit
-mock('./package.json', {
+mock(defaultPkgPath, {
   name: name,
   engines: {
     node: ">=1.2.0"
   }
-})
+});
 pleaseUpgrade();
 countShouldBe(0);
 
-mock('./package.json', {
+mock(defaultPkgPath, {
   name: name,
   engines: {
     node: ">=4.0.0"
@@ -34,7 +36,7 @@ mock('./package.json', {
 pleaseUpgrade();
 countShouldBe(0);
 
-mock('./package.json', {
+mock(defaultPkgPath, {
   name: name,
   engines: {
     node: ">=4"
@@ -45,7 +47,7 @@ countShouldBe(0);
 
 // Should call process.exit
 
-mock('./package.json', {
+mock(defaultPkgPath, {
   name: name,
   engines: {
     node: ">=4.0.1"
@@ -54,7 +56,7 @@ mock('./package.json', {
 pleaseUpgrade();
 countShouldBe(1);
 
-mock('./package.json', {
+mock(defaultPkgPath, {
   name: name,
   engines: {
     node: ">=6.0.0"
@@ -63,7 +65,7 @@ mock('./package.json', {
 pleaseUpgrade();
 countShouldBe(2);
 
-mock('./package.json', {
+mock(defaultPkgPath, {
   name: name,
   engines: {
     node: ">=8"
@@ -73,12 +75,12 @@ pleaseUpgrade();
 countShouldBe(3);
 
 // Should support pkgDir
-
-mock('../package.json', {
+var pkgPath = path.resolve(__dirname, "..") + "/package.json";
+mock(pkgPath, {
   name: name,
   engines: {
     node: ">=8"
   }
 });
-pleaseUpgrade('..');
+pleaseUpgrade("..");
 countShouldBe(4);


### PR DESCRIPTION
## Changelog

- Set the exported function name to `pleaseUpgradeNode`. Useful in stack traces.
- Resolve `package.json` relative to where ever `please-upgrade-node` was `require`d from
- Formatting(`npm run fix`)
- Add self to contributors
- Update tests
- Add note in readme for package resolution

Closes #5 