### PR TITLE
Throw error instead of using process.exit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,21 +5,25 @@ module.exports = function pleaseUpgradeNode(pkg, opts) {
   var requiredVersion = pkg.engines.node.replace('>=', '')
   var currentVersion = process.version.replace('v', '')
   if (semverCompare(currentVersion, requiredVersion) === -1) {
+    let errMsg
     if (opts.message) {
-      console.error(opts.message(requiredVersion))
+      errMsg = opts.message(requiredVersion)
     } else {
-      console.error(
-        pkg.name +
+      errMsg = pkg.name +
           ' requires at least version ' +
           requiredVersion +
           ' of Node, please upgrade'
-      )
+      
     }
 
+    console.error(errMsg)
+
     if (opts.hasOwnProperty('exitCode')) {
-      process.exit(opts.exitCode)
+      process.exitCode = opts.exitCode
     } else {
-      process.exit(1)
+      process.exitCode = 1
     }
+    
+    throw new Error(errMsg)
   }
 }

--- a/test.js
+++ b/test.js
@@ -4,12 +4,6 @@ var pleaseUpgrade = require('./')
 // Change process.version value
 Object.defineProperty(process, 'version', { value: 'v10.0.0' })
 
-// Mock process.exit and console.error
-var exitCode = null
-process.exit = function(code) {
-  exitCode = code
-}
-
 var errorMessage = null
 consoleError = console.error
 console.error = function(msg) {
@@ -19,57 +13,60 @@ console.error = function(msg) {
 
 function test(name, cb) {
   // Before each
-  exitCode = null
+  process.exitCode = null
   errorMessage = null
   // Test
   tape(name, cb)
 }
 
 // Actual tests
-test('>=1.2.0 should not exit', function(t) {
+test('>=1.2.0 should not throw', function(t) {
   pleaseUpgrade({
     name: 'Lorem Ipsum',
     engines: {
       node: '>=1.2.0'
     }
   })
-  t.equal(exitCode, null)
+  t.equal(process.exitCode, null)
   t.equal(errorMessage, null)
   t.end()
 })
 
-test('>=4 should not exit', function(t) {
+test('>=4 should not throw', function(t) {
   pleaseUpgrade({
     name: 'Lorem Ipsum',
     engines: {
       node: '>=4'
     }
   })
-  t.equal(exitCode, null)
+  t.equal(process.exitCode, null)
   t.equal(errorMessage, null)
   t.end()
 })
 
-test('>=4.0.0 should not exit', function(t) {
+test('>=4.0.0 should not throw', function(t) {
   pleaseUpgrade({
     name: 'Lorem Ipsum',
     engines: {
       node: '>=4.0.0'
     }
   })
-  t.equal(exitCode, null)
+  t.equal(process.exitCode, null)
   t.equal(errorMessage, null)
   t.end()
 })
 
-test('>=10.0.1 (patch) should exit', function(t) {
-  pleaseUpgrade({
-    name: 'Lorem Ipsum',
-    engines: {
-      node: '>=10.0.1'
-    }
+test('>=10.0.1 (patch) should throw', function(t) {
+  t.throws(function() {
+    pleaseUpgrade({
+      name: 'Lorem Ipsum',
+      engines: {
+        node: '>=10.0.1'
+      }
+    })
   })
-  t.equal(exitCode, 1)
+
+  t.equal(process.exitCode, 1)
   t.equal(
     errorMessage,
     'Lorem Ipsum requires at least version 10.0.1 of Node, please upgrade'
@@ -77,14 +74,17 @@ test('>=10.0.1 (patch) should exit', function(t) {
   t.end()
 })
 
-test('>=12 should exit', function(t) {
-  pleaseUpgrade({
-    name: 'Lorem Ipsum',
-    engines: {
-      node: '>=12'
-    }
+test('>=12 should throw', function(t) {
+  t.throws(function() {
+    pleaseUpgrade({
+      name: 'Lorem Ipsum',
+      engines: {
+        node: '>=12'
+      }
+    })
   })
-  t.equal(exitCode, 1)
+
+  t.equal(process.exitCode, 1)
   t.equal(
     errorMessage,
     'Lorem Ipsum requires at least version 12 of Node, please upgrade'
@@ -92,14 +92,17 @@ test('>=12 should exit', function(t) {
   t.end()
 })
 
-test('>=12.0.0 should exit', function(t) {
-  pleaseUpgrade({
-    name: 'Lorem Ipsum',
-    engines: {
-      node: '>=12.0.0'
-    }
+test('>=12.0.0 should throw', function(t) {
+  t.throws(function() {
+    pleaseUpgrade({
+      name: 'Lorem Ipsum',
+      engines: {
+        node: '>=12.0.0'
+      }
+    })
   })
-  t.equal(exitCode, 1)
+
+  t.equal(process.exitCode, 1)
   t.equal(
     errorMessage,
     'Lorem Ipsum requires at least version 12.0.0 of Node, please upgrade'
@@ -108,18 +111,21 @@ test('>=12.0.0 should exit', function(t) {
 })
 
 test('should exit with custom code 0', function(t) {
-  pleaseUpgrade(
-    {
-      name: 'Lorem Ipsum',
-      engines: {
-        node: '>=12.0.0'
+  t.throws(function() {
+    pleaseUpgrade(
+      {
+        name: 'Lorem Ipsum',
+        engines: {
+          node: '>=12.0.0'
+        }
+      },
+      {
+        exitCode: 0
       }
-    },
-    {
-      exitCode: 0
-    }
-  )
-  t.equal(exitCode, 0)
+    )
+  })
+
+  t.equal(process.exitCode, 0)
   t.equal(
     errorMessage,
     'Lorem Ipsum requires at least version 12.0.0 of Node, please upgrade'
@@ -128,18 +134,21 @@ test('should exit with custom code 0', function(t) {
 })
 
 test('should exit with custom code 2', function(t) {
-  pleaseUpgrade(
-    {
-      name: 'Lorem Ipsum',
-      engines: {
-        node: '>=12.0.0'
+  t.throws(function() {
+    pleaseUpgrade(
+      {
+        name: 'Lorem Ipsum',
+        engines: {
+          node: '>=12.0.0'
+        }
+      },
+      {
+        exitCode: 2
       }
-    },
-    {
-      exitCode: 2
-    }
-  )
-  t.equal(exitCode, 2)
+    )
+  })
+
+  t.equal(process.exitCode, 2)
   t.equal(
     errorMessage,
     'Lorem Ipsum requires at least version 12.0.0 of Node, please upgrade'
@@ -148,20 +157,23 @@ test('should exit with custom code 2', function(t) {
 })
 
 test('should display custom message', function(t) {
-  pleaseUpgrade(
-    {
-      name: 'Lorem Ipsum',
-      engines: {
-        node: '>=12.0.0'
+  t.throws(function() {
+    pleaseUpgrade(
+      {
+        name: 'Lorem Ipsum',
+        engines: {
+          node: '>=12.0.0'
+        }
+      },
+      {
+        message: function(requiredVersion) {
+          return 'Required version is ' + requiredVersion
+        }
       }
-    },
-    {
-      message: function(requiredVersion) {
-        return 'Required version is ' + requiredVersion
-      }
-    }
-  )
-  t.equal(exitCode, 1)
+    )
+  })
+
+  t.equal(process.exitCode, 1)
   t.equal(errorMessage, 'Required version is 12.0.0')
   t.end()
 })


### PR DESCRIPTION
👋 Hello first time contributor here,

This PR attempts to resolve #20 by throwing an error when a user needs to upgrade a node version. This will allow callers to gracefully handle the error and as mentioned in the issue, won't disrupt any asynchronous execution. 

One thing to mention in this PR is we no longer check the error message in the tests, I'm unsure how to assert the error of `t.throws()`.

Feedback appreciated! Thanks. 