### PR TITLE
handle general semver ranges, not just `>=`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,29 @@
-var semverCompare = require('semver-compare')
+var semver = require('semver')
 
 module.exports = function pleaseUpgradeNode(pkg, opts) {
   var opts = opts || {}
-  var requiredVersion = pkg.engines.node.replace('>=', '')
-  var currentVersion = process.version.replace('v', '')
-  if (semverCompare(currentVersion, requiredVersion) === -1) {
+
+  var minVersion = semver.minVersion(pkg.engines.node)
+  if (!semver.satisfies(process.version, pkg.engines.node)) {
     if (opts.message) {
-      console.error(opts.message(requiredVersion))
+      console.error(opts.message(minVersion))
     } else {
-      console.error(
-        pkg.name +
-          ' requires at least version ' +
-          requiredVersion +
-          ' of Node, please upgrade'
-      )
+      if (semver.lt(process.version, minVersion)) {
+        console.error(
+          pkg.name +
+            ' requires at least version ' +
+            minVersion +
+            ' of Node, please upgrade'
+        )
+      } else {
+        console.error(
+          pkg.name +
+            ' requires version range "' +
+            pkg.engines.node +
+            '" of Node, while currently on ' +
+          process.version
+        )
+      }
     }
 
     if (opts.hasOwnProperty('exitCode')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
-        "semver-compare": "^1.0.0"
+        "semver": "^5.7.1"
       },
       "devDependencies": {
         "tape": "^5.6.3"
@@ -893,10 +893,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "tape": "^5.6.3"
   },
   "dependencies": {
-    "semver-compare": "^1.0.0"
+    "semver": "^5.7.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -92,6 +92,21 @@ test('>=12 should exit', function(t) {
   t.end()
 })
 
+test('>10 should exit', function(t) {
+  pleaseUpgrade({
+    name: 'Lorem Ipsum',
+    engines: {
+      node: '>10'
+    }
+  })
+  t.equal(exitCode, 1)
+  t.equal(
+    errorMessage,
+    'Lorem Ipsum requires at least version 11.0.0 of Node, please upgrade'
+  )
+  t.end()
+})
+
 test('>=12.0.0 should exit', function(t) {
   pleaseUpgrade({
     name: 'Lorem Ipsum',

--- a/test.js
+++ b/test.js
@@ -87,7 +87,22 @@ test('>=12 should exit', function(t) {
   t.equal(exitCode, 1)
   t.equal(
     errorMessage,
-    'Lorem Ipsum requires at least version 12 of Node, please upgrade'
+    'Lorem Ipsum requires at least version 12.0.0 of Node, please upgrade'
+  )
+  t.end()
+})
+
+test('<1 should exit', function(t) {
+  pleaseUpgrade({
+    name: 'Lorem Ipsum',
+    engines: {
+      node: '<1'
+    }
+  })
+  t.equal(exitCode, 1)
+  t.equal(
+    errorMessage,
+    'Lorem Ipsum requires version range "<1" of Node, while currently on v10.0.0'
   )
   t.end()
 })


### PR DESCRIPTION
Fixes #37

- Replace abandoned dependency `semver-compare` with `semver`
  - `semver@5.7.1` is last version without nodejs version restriction
- Support any version spec, not just single simple  `>=X`.
- Add generic message when the problem is not simply being below min version (for example: user is on `13` while `engines.node` is `^12 || >=14`).
- Offloads all string-parsing from this module, making it simpler and more maintainable.